### PR TITLE
Add filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ And register it in the `params`
 ]
 ```
 Now you can use it like this
-```
+```php
 //controller action
 function addImage(ImageStorageInterface $imageStorage)
 {

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To define your own filesystems, you can configure it in the `config/params.php` 
 Aliases `runtimeStorage` and `documentStorage` will be automatically registered in the main application container.
 So, you can get it from the container
 ```php
-function index(ContainerInterface $container) 
+public function index(ContainerInterface $container) 
 {
     $documentStorage = $container->get('documentStorage');
 }
@@ -124,7 +124,7 @@ And register it in the `params`
 Now you can use it like this
 ```php
 //controller action
-function addImage(ImageStorageInterface $imageStorage)
+public function addImage(ImageStorageInterface $imageStorage)
 {
     //get image stream...
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <br>
 </p>
 
-The package provides an abstract filesystem to manage files and directories.
+An abstract filesystem to manage files and directories.
 
 [![Latest Stable Version](https://poser.pugx.org/yiisoft/yii-filesystem/v/stable.png)](https://packagist.org/packages/yiisoft/yii-filesystem)
 [![Total Downloads](https://poser.pugx.org/yiisoft/yii-filesystem/downloads.png)](https://packagist.org/packages/yiisoft/yii-filesystem)
@@ -14,9 +14,23 @@ The package provides an abstract filesystem to manage files and directories.
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/yiisoft/yii-filesystem/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/yiisoft/yii-filesystem/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/yiisoft/yii-filesystem/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/yiisoft/yii-filesystem/?branch=master)
 
-After you've installed the package, the `Yiisoft\Yii\Filesystem\FilesystemInterface` will be automatically registered 
+## Requirements
+
+The package requires PHP 7.4 and is meant to be used with Yii 3.
+
+## Installation
+
+```
+composer require yiisoft/yii-filesystem
+```
+
+After installation, the `Yiisoft\Yii\Filesystem\FilesystemInterface` will be automatically registered 
 in the main application container. This interface provides a local filesystem with root, as defined in the `@root` alias
-of the `aliases` parameter. So, you just use it anywhere this interface may be injected.
+of the `aliases` parameter.
+
+## Getting started
+
+The service could be obtained via DI container autowiring:
 
 ```php
 public function view(\Yiisoft\Yii\Filesystem\FilesystemInterface $filesystem)
@@ -25,11 +39,17 @@ public function view(\Yiisoft\Yii\Filesystem\FilesystemInterface $filesystem)
     //...
 }
 ```
+
 Also you can use aliases
+
 ```php
-    $someFileContent = $filesystem->write('@views/site/testfile.txt', 'Test content');
+$someFileContent = $filesystem->write('@views/site/testfile.txt', 'Test content');
 ```
-To define your own filesystems, you can configure it in the `config/params.php` as described below
+
+## Configuration
+
+Additional filesystems could be configured in `config/params.php` as described below:
+
 ```php
 'file.storage' => [
     'runtimeStorage' => [
@@ -81,8 +101,10 @@ To define your own filesystems, you can configure it in the `config/params.php` 
     ],
 ],
 ```
+
 Aliases `runtimeStorage` and `documentStorage` will be automatically registered in the main application container.
-So, you can get it from the container
+So, you can get it from the container:
+
 ```php
 public function index(ContainerInterface $container) 
 {
@@ -90,13 +112,16 @@ public function index(ContainerInterface $container)
 }
 ```
 
-If you want to use autowiring, you can create an own interface for your filesystem.
+If you prefer to use autowiring, you can create own interface for your filesystem.
+
 ```php
 interface ImageStorageInterface extends \Yiisoft\Yii\Filesystem\FilesystemInterface
 {
 }
 ```
-And register it in the `params`
+
+And then register it in the `params`:
+
 ```php
 'file.storage' => [
     ImageStorageInterface::class => [
@@ -121,7 +146,9 @@ And register it in the `params`
     ],
 ]
 ```
-Now you can use it like this
+
+Now you can use it like this:
+
 ```php
 //controller action
 public function addImage(ImageStorageInterface $imageStorage)
@@ -131,4 +158,5 @@ public function addImage(ImageStorageInterface $imageStorage)
     $imageStorage->writeStream('/path/to/image/myimage.jpeg', $myImageStream);
 }
 ```
+
 You can find documentation on `FilesystemInterface` methods in the [Flysystem Docs](https://flysystem.thephpleague.com/v2/docs/).  

--- a/README.md
+++ b/README.md
@@ -131,4 +131,4 @@ function addImage(ImageStorageInterface $imageStorage)
     $imageStorage->writeStream('/path/to/image/myimage.jpeg', $myImageStream);
 }
 ```
-You can find documentation on `FilesystemInterface` methods you can find in the [Flysystem Docs](https://flysystem.thephpleague.com/v2/docs/).  
+You can find documentation on `FilesystemInterface` methods in the [Flysystem Docs](https://flysystem.thephpleague.com/v2/docs/).  

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <br>
 </p>
 
-The package ...
+The package provides an abstract filesystem to manage files and directories.
 
 [![Latest Stable Version](https://poser.pugx.org/yiisoft/yii-filesystem/v/stable.png)](https://packagist.org/packages/yiisoft/yii-filesystem)
 [![Total Downloads](https://poser.pugx.org/yiisoft/yii-filesystem/downloads.png)](https://packagist.org/packages/yiisoft/yii-filesystem)
@@ -14,5 +14,121 @@ The package ...
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/yiisoft/yii-filesystem/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/yiisoft/yii-filesystem/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/yiisoft/yii-filesystem/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/yiisoft/yii-filesystem/?branch=master)
 
-## General usage
+After you've installed the package, the `Yiisoft\Yii\Filesystem\FilesystemInterface` will be automatically registered 
+in the main application container. This interface provides a local filesystem with root, as defined in the `@root` alias
+of the `aliases` parameter. So, you just use it anywhere this interface may be injected.
 
+```php
+public function view(\Yiisoft\Yii\Filesystem\FilesystemInterface $filesystem)
+{
+    $someFileContent = $filesystem->read('/runtime/somefile.txt');
+    //...
+}
+```
+Also you can use aliases
+```php
+    $someFileContent = $filesystem->write('@views/site/testfile.txt', 'Test content');
+```
+To define your own filesystems, you can configure it in the `config/params.php` as described below
+```php
+'file.storage' => [
+    'runtimeStorage' => [
+        'adapter' => [
+            '__class' => \League\Flysystem\Local\LocalFilesystemAdapter::class,
+            '__construct()' => [
+                dirname(__DIR__) . '/runtime',
+                \League\Flysystem\UnixVisibility\PortableVisibilityConverter::fromArray([
+                    'file' => [
+                        'public' => 0644,
+                        'private' => 0600,
+                    ],
+                    'dir' => [
+                        'public' => 0755,
+                        'private' => 0700,
+                    ],
+                ]),
+                LOCK_EX,
+                \League\Flysystem\Local\LocalFilesystemAdapter::DISALLOW_LINKS
+            ]
+        ],
+        'aliases' => [
+            '@cache' => '@root/cache',
+        ]
+    ],
+    'documentStorage' => [
+        'adapter' => [
+            '__class' => \League\Flysystem\Local\LocalFilesystemAdapter::class,
+            '__construct()' => [
+                dirname(__DIR__) . '/docs',
+                \League\Flysystem\UnixVisibility\PortableVisibilityConverter::fromArray([
+                    'file' => [
+                        'public' => 0644,
+                        'private' => 0600,
+                        ],
+                    'dir' => [
+                        'public' => 0755,
+                        'private' => 0700,
+                        ],
+                    ]),
+                    LOCK_EX,
+                    \League\Flysystem\Local\LocalFilesystemAdapter::DISALLOW_LINKS
+                ]
+        ],
+        'aliases' => [
+             '@invoices' => '@root/export/invoices',
+             '@orders' => '@root/export/orders',
+        ],
+    ],
+],
+```
+Aliases `runtimeStorage` and `documentStorage` will be automatically registered in the main application container.
+So, you can get it from the container
+```php
+function index(ContainerInterface $container) 
+{
+    $documentStorage = $container->get('documentStorage');
+}
+```
+
+If you want to use autowiring, you can create an own interface for your filesystem.
+```php
+interface ImageStorageInterface extends \Yiisoft\Yii\Filesystem\FilesystemInterface
+{
+}
+```
+And register it in the `params`
+```php
+'file.storage' => [
+    ImageStorageInterface::class => [
+        'adapter' => [
+            '__class' => \League\Flysystem\Local\LocalFilesystemAdapter::class,
+            '__construct()' => [
+                dirname(__DIR__) . '/storage/images',
+                \League\Flysystem\UnixVisibility\PortableVisibilityConverter::fromArray([
+                    'file' => [
+                        'public' => 0644,
+                        'private' => 0600,
+                    ],
+                    'dir' => [
+                        'public' => 0755,
+                        'private' => 0700,
+                    ],
+                ]),
+                LOCK_EX,
+                \League\Flysystem\Local\LocalFilesystemAdapter::DISALLOW_LINKS
+            ]
+        ],
+    ],
+]
+```
+Now you can use it like this
+```
+//controller action
+function addImage(ImageStorageInterface $imageStorage)
+{
+    //get image stream...
+
+    $imageStorage->writeStream('/path/to/image/myimage.jpeg', $myImageStream);
+}
+```
+You can find documentation on `FilesystemInterface` methods you can find in the [Flysystem Docs](https://flysystem.thephpleague.com/v2/docs/).  

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,10 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4"
+        "php": "^7.4",
+        "league/flysystem": "^2.0@dev",
+        "yiisoft/aliases": "^3.0@dev",
+        "yiisoft/di": "^3.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
@@ -36,6 +39,10 @@
     "extra": {
         "branch-alias": {
             "dev-master": "3.0.x-dev"
+        },
+        "config-plugin": {
+            "common": "config/common.php",
+            "providers": "config/providers.php"
         }
     },
     "scripts": {

--- a/config/common.php
+++ b/config/common.php
@@ -7,7 +7,7 @@ use Yiisoft\Yii\Filesystem\Filesystem;
 use Yiisoft\Yii\Filesystem\FileStorageConfigs;
 
 return [
-    FilesystemInterface::class => function () use ($params) {
+    FilesystemInterface::class => static function () use ($params) {
         $aliases = $params['aliases'] ?? [];
         if (!isset($aliases['@root'])) {
             throw new \RuntimeException('Alias of the root directory is not defined.');
@@ -30,7 +30,7 @@ return [
         );
         return new Filesystem($adapter, $aliases);
     },
-    FileStorageConfigs::class => function () use ($params) {
+    FileStorageConfigs::class => static function () use ($params) {
         $configs = $params['file.storage'] ?? [];
         return new FileStorageConfigs($configs);
     }

--- a/config/common.php
+++ b/config/common.php
@@ -1,0 +1,37 @@
+<?php
+
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
+use Yiisoft\Yii\Filesystem\FilesystemInterface;
+use Yiisoft\Yii\Filesystem\Filesystem;
+use Yiisoft\Yii\Filesystem\FileStorageConfigs;
+
+return [
+    FilesystemInterface::class => function () use ($params) {
+        $aliases = $params['aliases'] ?? [];
+        if (!isset($aliases['@root'])) {
+            throw new \RuntimeException('Alias of the root directory is not defined.');
+        }
+
+        $adapter = new LocalFilesystemAdapter(
+            $aliases['@root'],
+            PortableVisibilityConverter::fromArray([
+                'file' => [
+                    'public' => 0644,
+                    'private' => 0600,
+                ],
+                'dir' => [
+                    'public' => 0755,
+                    'private' => 0700,
+                ],
+            ]),
+            LOCK_EX,
+            LocalFilesystemAdapter::DISALLOW_LINKS
+        );
+        return new Filesystem($adapter, $aliases);
+    },
+    FileStorageConfigs::class => function () use ($params) {
+        $configs = $params['file.storage'] ?? [];
+        return new FileStorageConfigs($configs);
+    }
+];

--- a/config/providers.php
+++ b/config/providers.php
@@ -3,5 +3,5 @@
 use Yiisoft\Yii\Filesystem\FileStorageServiceProvider;
 
 return [
-  FileStorageServiceProvider::class
+    'FileStorage' => FileStorageServiceProvider::class
 ];

--- a/config/providers.php
+++ b/config/providers.php
@@ -1,0 +1,7 @@
+<?php
+
+use Yiisoft\Yii\Filesystem\FileStorageServiceProvider;
+
+return [
+  FileStorageServiceProvider::class
+];

--- a/src/FileStorageConfigs.php
+++ b/src/FileStorageConfigs.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yiisoft\Yii\Filesystem;
+
+final class FileStorageConfigs
+{
+    private array $storageConfigs = [];
+
+    public function __construct(array $storageConfigs)
+    {
+        $this->storageConfigs = $storageConfigs;
+    }
+
+    public function getConfigs(): array
+    {
+        return $this->storageConfigs;
+    }
+}

--- a/src/FileStorageConfigs.php
+++ b/src/FileStorageConfigs.php
@@ -4,7 +4,7 @@ namespace Yiisoft\Yii\Filesystem;
 
 final class FileStorageConfigs
 {
-    private array $storageConfigs = [];
+    private array $storageConfigs;
 
     public function __construct(array $storageConfigs)
     {

--- a/src/FileStorageServiceProvider.php
+++ b/src/FileStorageServiceProvider.php
@@ -29,7 +29,7 @@ final class FileStorageServiceProvider extends ServiceProvider
             throw new \RuntimeException("Adapter is not defined in the '$alias' storage config.");
         }
         if (!is_subclass_of($adapter, FilesystemAdapter::class)) {
-            throw new \RuntimeException("Adapter must implements FilesystemAdapterInterface.");
+            throw new \RuntimeException("Adapter must implements FilesystemAdapter interface.");
         }
     }
 }

--- a/src/FileStorageServiceProvider.php
+++ b/src/FileStorageServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Yiisoft\Yii\Filesystem;
+
+use League\Flysystem\FilesystemAdapter;
+use Yiisoft\Di\Container;
+use Yiisoft\Di\Support\ServiceProvider;
+use Yiisoft\Factory\Factory;
+
+final class FileStorageServiceProvider extends ServiceProvider
+{
+    public function register(Container $container): void
+    {
+        $factory = new Factory();
+        $configs = $container->get(FileStorageConfigs::class)->getConfigs();
+        foreach ($configs as $alias => $config) {
+            $this->validateAdapter($alias, $config);
+            $configParams = $config['config'] ?? [];
+            $aliases = $config['aliases'] ?? [];
+            $adapter = $factory->create($config['adapter']);
+            $container->set($alias, fn () => new Filesystem($adapter, $aliases, $configParams));
+        }
+    }
+
+    private function validateAdapter(string $alias, array $config)
+    {
+        $adapter = $config['adapter']['__class'] ?? false;
+        if (!$adapter) {
+            throw new \RuntimeException("Adapter is not defined in the '$alias' storage config.");
+        }
+        if (!is_subclass_of($adapter, FilesystemAdapter::class)) {
+            throw new \RuntimeException("Adapter must implements FilesystemAdapterInterface.");
+        }
+    }
+}

--- a/src/FileStorageServiceProvider.php
+++ b/src/FileStorageServiceProvider.php
@@ -26,10 +26,11 @@ final class FileStorageServiceProvider extends ServiceProvider
     {
         $adapter = $config['adapter']['__class'] ?? false;
         if (!$adapter) {
-            throw new \RuntimeException("Adapter is not defined in the '$alias' storage config.");
+            throw new \RuntimeException("Adapter is not defined in the \"$alias\" storage config.");
         }
-        if (!is_subclass_of($adapter, FilesystemAdapter::class)) {
-            throw new \RuntimeException('Adapter must implement FilesystemAdapter interface.');
+
+        if (!$adapter instanceof FilesystemAdapter) {
+            throw new \RuntimeException('Adapter must implement \League\Flysystem\FilesystemAdapter interface.');
         }
     }
 }

--- a/src/FileStorageServiceProvider.php
+++ b/src/FileStorageServiceProvider.php
@@ -22,14 +22,14 @@ final class FileStorageServiceProvider extends ServiceProvider
         }
     }
 
-    private function validateAdapter(string $alias, array $config)
+    private function validateAdapter(string $alias, array $config): void
     {
         $adapter = $config['adapter']['__class'] ?? false;
         if (!$adapter) {
             throw new \RuntimeException("Adapter is not defined in the '$alias' storage config.");
         }
         if (!is_subclass_of($adapter, FilesystemAdapter::class)) {
-            throw new \RuntimeException("Adapter must implements FilesystemAdapter interface.");
+            throw new \RuntimeException('Adapter must implement FilesystemAdapter interface.');
         }
     }
 }

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -2,12 +2,13 @@
 
 namespace Yiisoft\Yii\Filesystem;
 
+use League\Flysystem\DirectoryListing;
 use League\Flysystem\Filesystem as LeagueFilesystem;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\PathNormalizer;
 use Yiisoft\Aliases\Aliases;
 
-class Filesystem extends LeagueFilesystem implements FilesystemInterface
+final class Filesystem extends LeagueFilesystem implements FilesystemInterface
 {
     private Aliases $aliases;
 
@@ -104,7 +105,7 @@ class Filesystem extends LeagueFilesystem implements FilesystemInterface
         return parent::lastModified($path);
     }
 
-    public function listContents(string $location, bool $deep = LeagueFilesystem::LIST_SHALLOW): \League\Flysystem\DirectoryListing
+    public function listContents(string $location, bool $deep = LeagueFilesystem::LIST_SHALLOW): DirectoryListing
     {
         $location = $this->aliases->get($location);
         return parent::listContents($location, $deep);

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Yiisoft\Yii\Filesystem;
+
+use League\Flysystem\Filesystem as LeagueFilesystem;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\PathNormalizer;
+use Yiisoft\Aliases\Aliases;
+
+class Filesystem extends LeagueFilesystem implements FilesystemInterface
+{
+    private Aliases $aliases;
+
+    public function __construct(FilesystemAdapter $adapter, array $aliases = [], array $config = [], PathNormalizer $pathNormalizer = null)
+    {
+        $this->prepareAliases($aliases);
+
+        parent::__construct($adapter, $config, $pathNormalizer);
+    }
+
+    public function fileExists(string $location): bool
+    {
+        $location = $this->aliases->get($location);
+        return parent::fileExists($location);
+    }
+
+    public function write(string $location, string $contents, array $config = []): void
+    {
+        $location = $this->aliases->get($location);
+        parent::write($location, $contents, $config);
+    }
+
+    public function writeStream(string $location, $contents, array $config = []): void
+    {
+        $location = $this->aliases->get($location);
+        parent::writeStream($location, $contents, $config);
+    }
+
+    public function read(string $location): string
+    {
+        $location = $this->aliases->get($location);
+        return parent::read($location);
+    }
+
+    public function readStream(string $location)
+    {
+        $location = $this->aliases->get($location);
+        return parent::readStream($location);
+    }
+
+    public function delete(string $location): void
+    {
+        $location = $this->aliases->get($location);
+        parent::delete($location);
+    }
+
+    public function createDirectory(string $location, array $config = []): void
+    {
+        $location = $this->aliases->get($location);
+        parent::createDirectory($location, $config);
+    }
+
+    public function deleteDirectory(string $location): void
+    {
+        $location = $this->aliases->get($location);
+        parent::deleteDirectory($location);
+    }
+
+    public function copy(string $source, string $destination, array $config = []): void
+    {
+        $source = $this->aliases->get($source);
+        $destination = $this->aliases->get($destination);
+        parent::copy($source, $destination, $config);
+    }
+
+    public function move(string $source, string $destination, array $config = []): void
+    {
+        $source = $this->aliases->get($source);
+        $destination = $this->aliases->get($destination);
+        parent::move($source, $destination, $config);
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $path = $this->aliases->get($path);
+        parent::setVisibility($path, $visibility);
+    }
+
+    public function visibility(string $path): string
+    {
+        $path = $this->aliases->get($path);
+        return parent::visibility($path);
+    }
+
+    public function mimeType(string $path): string
+    {
+        $path = $this->aliases->get($path);
+        return parent::mimeType($path);
+    }
+
+    public function lastModified(string $path): int
+    {
+        $path = $this->aliases->get($path);
+        return parent::lastModified($path);
+    }
+
+    public function listContents(string $location, bool $deep = LeagueFilesystem::LIST_SHALLOW): \League\Flysystem\DirectoryListing
+    {
+        $location = $this->aliases->get($location);
+        return parent::listContents($location, $deep);
+    }
+
+    public function fileSize(string $path): int
+    {
+        $path = $this->aliases->get($path);
+        return parent::fileSize($path);
+    }
+
+    private function prepareAliases(array $aliases): void
+    {
+        if ($aliases !== []) {
+            $aliases = array_merge(['@root' => ''], $aliases);
+            $aliases['@root'] = '';
+        }
+        $this->aliases = new Aliases($aliases);
+    }
+}

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Yiisoft\Yii\Filesystem;
+
+use League\Flysystem\FilesystemOperator;
+
+interface FilesystemInterface extends FilesystemOperator
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | https://github.com/yiisoft/files/issues/11

After the package is installed you can just get `Yiisoft\Files\FilesystemInterface` to get the local filesystem with root as defined in the `@root` alias (commonly is a project root). Aliases are supported.
```php
public function index(FilesystemInterface $filesystem): ResponseInterface
{
    $filesystem->write('@views/site/test.txt', 'Test');
}
```
Also you can define any quantity of file storages in the `config/params.php` 
```php
'file.storage' => [
        'runtimeStorage' => [
            'adapter' => [
                '__class' => \League\Flysystem\Local\LocalFilesystemAdapter::class,
                '__construct()' => [
                    dirname(__DIR__) . '/runtime',
                    \League\Flysystem\UnixVisibility\PortableVisibilityConverter::fromArray([
                        'file' => [
                            'public' => 0644,
                            'private' => 0600,
                        ],
                        'dir' => [
                            'public' => 0755,
                            'private' => 0700,
                        ],
                    ]),
                    LOCK_EX,
                    \League\Flysystem\Local\LocalFilesystemAdapter::DISALLOW_LINKS
                ]
            ],
            'aliases' => [
                '@cache' => '@root/cache',
            ]
        ]
    ],
```
After that you can get the selected filesystem from the container by the alias.
```php
public function index(ContainerInterface $container): ResponseInterface
{ 
    $runtimeFilesystem = $container->get('runtimeStorage');
    $runtimeFilesystem->write('@cache/test-cache.txt', 'Test Cache'));
}
```